### PR TITLE
Use unique service instance ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = function expMetrics(applicationName = "exp-metrics", config = {
   const resourceConfig = {
     "service.name": applicationName,
     "service.namespace": `${process.env.NODE_ENV === "production" ? "prod" : process.env.NODE_ENV}`,
-    "service.instance.id": process.env.GOOGLE_CLOUD_PROJECT,
+    "service.instance.id": crypto.randomUUID(),
     ...config,
   };
   const exporter = new MetricExporter();

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -16,14 +16,18 @@ const expMetrics = proxyquire("..", {
 
 describe("API", () => {
   let metrics;
+  let randomUUID;
 
   describe("initialization", () => {
     before(() => {
       process.env.GOOGLE_CLOUD_PROJECT = "env-project";
+      randomUUID = crypto.randomUUID;
+      crypto.randomUUID = () => "random-uuid";
     });
 
     after(() => {
       delete process.env.GOOGLE_CLOUD_PROJECT;
+      crypto.randomUUID = randomUUID;
     });
 
     it("no arguments", () => {
@@ -31,7 +35,7 @@ describe("API", () => {
       expect(mockResource.ctorArgs.at(-1)).to.deep.equal({
         "service.name": "exp-metrics",
         "service.namespace": "test",
-        "service.instance.id": "env-project",
+        "service.instance.id": "random-uuid",
       });
     });
 
@@ -40,7 +44,7 @@ describe("API", () => {
       expect(mockResource.ctorArgs.at(-1)).to.deep.equal({
         "service.name": "test-app",
         "service.namespace": "test",
-        "service.instance.id": "env-project",
+        "service.instance.id": "random-uuid",
       });
     });
 


### PR DESCRIPTION
The instance ID needs to be unique per running instance, in order for
the exporter to function properly.

Best practice seems to be to use a random string.
