### PR TITLE
Revive default metrics middleware and fix histogram aggregation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { MetricExporter } = require("@google-cloud/opentelemetry-cloud-monitoring-exporter");
-const { MeterProvider, PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
+const { MeterProvider, PeriodicExportingMetricReader, InstrumentType, ExponentialHistogramAggregation, View } = require("@opentelemetry/sdk-metrics");
 const { Resource } = require("@opentelemetry/resources");
 const { GcpDetectorSync } = require("@google-cloud/opentelemetry-resource-util");
 const crypto = require("crypto");
@@ -92,6 +92,10 @@ module.exports = function expMetrics(applicationName = "exp-metrics", config = {
     const meterProvider = new MeterProvider({
       readers: [ reader ],
       resource: new Resource(resourceConfig).merge(new GcpDetectorSync().detect()),
+      views: [ new View({
+        instrumentType: InstrumentType.HISTOGRAM,
+        aggregation: new ExponentialHistogramAggregation(),
+      }) ],
     });
     meter = meterProvider.getMeter("exp-metrics");
 

--- a/index.js
+++ b/index.js
@@ -4,12 +4,13 @@ const { MetricExporter } = require("@google-cloud/opentelemetry-cloud-monitoring
 const { MeterProvider, PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
 const { Resource } = require("@opentelemetry/resources");
 const { GcpDetectorSync } = require("@google-cloud/opentelemetry-resource-util");
+const crypto = require("crypto");
 
 module.exports = function expMetrics(applicationName = "exp-metrics", config = {}) {
   const resourceConfig = {
     "service.name": applicationName,
     "service.namespace": `${process.env.NODE_ENV === "production" ? "prod" : process.env.NODE_ENV}`,
-    "service.instance.id": process.env.GOOGLE_CLOUD_PROJECT,
+    "service.instance.id": crypto.randomUUID(),
     ...config,
   };
   const exporter = new MetricExporter();

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -7,17 +7,20 @@ const { expect } = require("chai");
 const mockMeterProvider = require("./helpers/mockMeterProvider.js");
 const mockResource = require("./helpers/mockResource.js");
 
-const expMetrics = proxyquire("..", {
-  "@opentelemetry/sdk-metrics": {
-    MeterProvider: mockMeterProvider,
-    PeriodicExportingMetricReader: function () {},
-  },
-  "@opentelemetry/resources": mockResource,
-});
-
 describe("API", () => {
+  let expMetrics;
   let metrics;
   let randomUUID;
+
+  beforeEach(() => {
+    expMetrics = proxyquire("..", {
+      "@opentelemetry/sdk-metrics": {
+        MeterProvider: mockMeterProvider,
+        PeriodicExportingMetricReader: function () {},
+      },
+      "@opentelemetry/resources": mockResource,
+    });
+  });
 
   describe("initialization", () => {
     before(() => {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -3,6 +3,7 @@
 const crypto = require("crypto");
 const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 const { expect } = require("chai");
+const sdkMetrics = require("@opentelemetry/sdk-metrics");
 
 const mockMeterProvider = require("./helpers/mockMeterProvider.js");
 const mockResource = require("./helpers/mockResource.js");
@@ -15,8 +16,8 @@ describe("API", () => {
   beforeEach(() => {
     expMetrics = proxyquire("..", {
       "@opentelemetry/sdk-metrics": {
+        ...sdkMetrics,
         MeterProvider: mockMeterProvider,
-        PeriodicExportingMetricReader: function () {},
       },
       "@opentelemetry/resources": mockResource,
     });

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("crypto");
 const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
 const { expect } = require("chai");
 
@@ -16,14 +17,18 @@ const expMetrics = proxyquire("..", {
 
 describe("API", () => {
   let metrics;
+  let randomUUID;
 
   describe("initialization", () => {
     before(() => {
       process.env.GOOGLE_CLOUD_PROJECT = "env-project";
+      randomUUID = crypto.randomUUID;
+      crypto.randomUUID = () => "random-uuid";
     });
 
     after(() => {
       delete process.env.GOOGLE_CLOUD_PROJECT;
+      crypto.randomUUID = randomUUID;
     });
 
     it("no arguments", () => {
@@ -31,7 +36,7 @@ describe("API", () => {
       expect(mockResource.ctorArgs.at(-1)).to.deep.equal({
         "service.name": "exp-metrics",
         "service.namespace": "test",
-        "service.instance.id": "env-project",
+        "service.instance.id": "random-uuid",
       });
     });
 
@@ -40,7 +45,7 @@ describe("API", () => {
       expect(mockResource.ctorArgs.at(-1)).to.deep.equal({
         "service.name": "test-app",
         "service.namespace": "test",
-        "service.instance.id": "env-project",
+        "service.instance.id": "random-uuid",
       });
     });
 

--- a/test/helpers/testRequestBody.js
+++ b/test/helpers/testRequestBody.js
@@ -6,6 +6,7 @@ module.exports = function testRequestBody(testNode, actualNode, path = "body") {
   Object.keys(testNode).forEach((key) => {
     const current = testNode[key];
     if (typeof current === "object") {
+      expect(actualNode).to.have.property(key);
       testRequestBody(current, actualNode[key], `${path}.${key}`);
     } else {
       expect(actualNode[key], `Request mismatch on ${path}.${key}`).to.equal(testNode[key]);

--- a/test/metrics-test.js
+++ b/test/metrics-test.js
@@ -202,19 +202,17 @@ describe("metrics", () => {
                   count: "2",
                   mean: 15,
                   bucketOptions: {
-                    explicitBuckets: {
-                      bounds: [
-                        0.5,
-                        0.95,
-                        0.99,
-                      ],
+                    exponentialBuckets: {
+                      growthFactor: 1.0054299011128027,
+                      scale: 9.988807817513237,
+                      numFiniteBuckets: 129,
                     },
                   },
                   bucketCounts: [
                     "0",
+                    "1",
                     "0",
                     "0",
-                    "2",
                   ],
                 },
               },

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const proxyquire = require("proxyquire").noCallThru().noPreserveCache();
+const request = require("supertest");
+const express = require("express");
+const nock = require("nock");
+const { expect } = require("chai");
+
+const mockResource = require("./helpers/mockResource.js");
+const createHistogramSpy = spy({ record: spy() });
+const createCounterSpy = spy({ add: spy() });
+
+const expMetrics = proxyquire("..", {
+  "@opentelemetry/sdk-metrics": {
+    MeterProvider: function MeterProvider() {
+      return {
+        getMeter() {
+          return {
+            createHistogram: createHistogramSpy,
+            createCounter: createCounterSpy,
+          };
+        },
+      };
+    },
+    PeriodicExportingMetricReader: function () {},
+  },
+  "@opentelemetry/resources": mockResource,
+});
+
+Feature("middleware", () => {
+  let app;
+  let originalDateNow;
+
+  before(() => {
+    nock.enableNetConnect();
+    originalDateNow = Date.now;
+    const timeStamps = [ 100, 142, 200, 237 ];
+    Date.now = () => timeStamps.shift() || originalDateNow();
+  });
+
+  after(() => {
+    Date.now = originalDateNow;
+  });
+
+  Given("An Express app", () => {
+    app = express();
+  });
+
+  When("the app is using our response time middleware", () => {
+    const metrics = expMetrics("test-app");
+    app.use(metrics.responseTimeMiddleware);
+  });
+
+  Then("a response time metric should have been created", () => {
+    expect(createHistogramSpy.calls).to.deep.equal([ [ "http_response_time_milliseconds", { description: "Response times in milliseconds" } ] ]);
+  });
+
+  And("a response counter should have been created", () => {
+    expect(createCounterSpy.calls).to.deep.equal([ [ "http_responses_total", { description: "Number of HTTP responses" } ] ]);
+  });
+
+  Given("the app has a route", () => {
+    app.get("/path", (_req, res) => {
+      res.send("Hello, world!");
+    });
+  });
+
+  When("two requests are made to the Express app", async () => {
+    await request(app).get("/path");
+    await request(app).get("/path");
+  });
+
+  Then("the response time metric should have been called", () => {
+    expect(createHistogramSpy.record.calls).to.deep.equal([
+      [ 42 ],
+      [ 37 ],
+    ]);
+  });
+
+  And("the response time metric should have been called", () => {
+    expect(createCounterSpy.add.calls).to.deep.equal([
+      [ 1, { status_code: 200, method: "GET" } ],
+      [ 1, { status_code: 200, method: "GET" } ],
+    ]);
+  });
+});
+
+function spy(props = {}) {
+  function fakeFunction(...args) {
+    fakeFunction.calls.push(args);
+    return props;
+  }
+
+  Object.assign(fakeFunction, { calls: [] }, props);
+
+  return fakeFunction;
+}

--- a/test/middleware-test.js
+++ b/test/middleware-test.js
@@ -5,6 +5,7 @@ const request = require("supertest");
 const express = require("express");
 const nock = require("nock");
 const { expect } = require("chai");
+const sdkMetrics = require("@opentelemetry/sdk-metrics");
 
 const mockResource = require("./helpers/mockResource.js");
 const createHistogramSpy = spy({ record: spy() });
@@ -12,6 +13,7 @@ const createCounterSpy = spy({ add: spy() });
 
 const expMetrics = proxyquire("..", {
   "@opentelemetry/sdk-metrics": {
+    ...sdkMetrics,
     MeterProvider: function MeterProvider() {
       return {
         getMeter() {
@@ -22,7 +24,6 @@ const expMetrics = proxyquire("..", {
         },
       };
     },
-    PeriodicExportingMetricReader: function () {},
   },
   "@opentelemetry/resources": mockResource,
 });


### PR DESCRIPTION
- **Revive default metrics middleware**
  - This was erroneously removed in 2.0.0.
  - It is a core stat, used by a lot of dashboards
- **Use unique service instance ID**
  - The instance ID needs to be unique per running instance, in order for
    the exporter to function properly.
  - Best practice seems to be to use a random string.
- **Use exponential histogram aggregation**
  - This is the default histogram type used by Prometheus, and what we
    expect to use in dashboards.
